### PR TITLE
feat(notifications): real-time in-app notifications for collectors

### DIFF
--- a/app/(collector)/notifications.tsx
+++ b/app/(collector)/notifications.tsx
@@ -1,13 +1,169 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useNotifications } from '@/hooks/useNotifications';
+import type { Notification, NotificationType } from '@/types';
+
+function relativeTime(dateString: string): string {
+  const diff = Date.now() - new Date(dateString).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days === 1) return 'Yesterday';
+  if (days < 7) return `${days}d ago`;
+  return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' }).format(
+    new Date(dateString)
+  );
+}
+
+function groupByDay(items: Notification[]): { label: string; items: Notification[] }[] {
+  const groups: Record<string, Notification[]> = {};
+  const today = new Date().toDateString();
+  const yesterday = new Date(Date.now() - 86400000).toDateString();
+
+  for (const n of items) {
+    const d = new Date(n.created_at).toDateString();
+    const label =
+      d === today
+        ? 'Today'
+        : d === yesterday
+        ? 'Yesterday'
+        : new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' }).format(
+            new Date(n.created_at)
+          );
+    if (!groups[label]) groups[label] = [];
+    groups[label].push(n);
+  }
+
+  return Object.entries(groups).map(([label, items]) => ({ label, items }));
+}
+
+type IconConfig = { name: React.ComponentProps<typeof Ionicons>['name']; bg: string; color: string };
+
+function iconFor(type: NotificationType): IconConfig {
+  switch (type) {
+    case 'order_status_changed':
+      return { name: 'receipt-outline',     bg: 'bg-blue-50',   color: '#3b82f6' };
+    case 'low_stock':
+      return { name: 'warning-outline',     bg: 'bg-orange-50', color: '#f97316' };
+    case 'out_of_stock':
+      return { name: 'close-circle-outline', bg: 'bg-red-50',   color: '#ef4444' };
+    case 'price_changed':
+      return { name: 'pricetag-outline',    bg: 'bg-purple-50', color: '#a855f7' };
+    case 'new_product':
+      return { name: 'sparkles-outline',    bg: 'bg-green-50',  color: '#22c55e' };
+  }
+}
+
+function NotificationRow({
+  item,
+  onPress,
+}: {
+  item: Notification;
+  onPress: (id: string) => void;
+}) {
+  const icon = iconFor(item.type);
+  return (
+    <TouchableOpacity
+      className={`flex-row items-start px-4 py-3 ${!item.is_read ? 'bg-blue-50/40' : 'bg-white'}`}
+      onPress={() => { if (!item.is_read) onPress(item.id); }}
+      activeOpacity={0.7}
+    >
+      {/* Unread dot */}
+      <View className="w-2 mt-2 mr-2 items-center">
+        {!item.is_read && <View className="w-2 h-2 rounded-full bg-blue-500" />}
+      </View>
+
+      {/* Type icon */}
+      <View className={`w-9 h-9 rounded-full ${icon.bg} items-center justify-center mr-3 mt-0.5`}>
+        <Ionicons name={icon.name} size={18} color={icon.color} />
+      </View>
+
+      {/* Text */}
+      <View className="flex-1">
+        <Text
+          className={`text-sm ${!item.is_read ? 'font-bold text-gray-900' : 'font-semibold text-gray-700'}`}
+          numberOfLines={1}
+        >
+          {item.title}
+        </Text>
+        <Text className="text-xs text-gray-500 mt-0.5 leading-4" numberOfLines={2}>
+          {item.body}
+        </Text>
+        <Text className="text-[11px] text-gray-400 mt-1">{relativeTime(item.created_at)}</Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
 
 export default function NotificationsScreen() {
+  const { notifications, loading, unreadCount, markAsRead, markAllAsRead } = useNotifications();
+
+  if (loading) {
+    return (
+      <View className="flex-1 bg-gray-50 items-center justify-center">
+        <ActivityIndicator size="large" color="#3b82f6" />
+      </View>
+    );
+  }
+
+  if (notifications.length === 0) {
+    return (
+      <View className="flex-1 bg-gray-50 items-center justify-center px-4">
+        <View className="w-16 h-16 bg-gray-100 rounded-full items-center justify-center mb-4">
+          <Ionicons name="notifications-outline" size={32} color="#d1d5db" />
+        </View>
+        <Text className="text-gray-600 text-base font-semibold">No notifications yet</Text>
+        <Text className="text-gray-400 text-sm mt-1 text-center">
+          You'll be notified about order updates, stock changes, and price changes.
+        </Text>
+      </View>
+    );
+  }
+
+  const groups = groupByDay(notifications);
+
   return (
-    <View className="flex-1 bg-gray-50 items-center justify-center px-4">
-      <Ionicons name="notifications-outline" size={48} color="#d1d5db" />
-      <Text className="text-gray-500 text-lg font-medium mt-4">No notifications yet</Text>
-      <Text className="text-gray-400 text-sm mt-1">You're all caught up!</Text>
+    <View className="flex-1 bg-gray-50">
+      {unreadCount > 0 && (
+        <View className="flex-row items-center justify-between px-4 py-2.5 bg-white border-b border-gray-100">
+          <Text className="text-xs text-gray-500">
+            {unreadCount} unread notification{unreadCount !== 1 ? 's' : ''}
+          </Text>
+          <TouchableOpacity onPress={markAllAsRead}>
+            <Text className="text-xs text-blue-600 font-semibold">Mark all as read</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      <ScrollView contentContainerStyle={{ paddingBottom: 32 }}>
+        {groups.map(({ label, items }) => (
+          <View key={label}>
+            <View className="px-4 pt-4 pb-1">
+              <Text className="text-xs font-semibold text-gray-400 uppercase tracking-wide">
+                {label}
+              </Text>
+            </View>
+            <View className="bg-white border-y border-gray-100 overflow-hidden">
+              {items.map((item, index) => (
+                <View key={item.id}>
+                  <NotificationRow item={item} onPress={markAsRead} />
+                  {index < items.length - 1 && <View className="h-px bg-gray-100 ml-14" />}
+                </View>
+              ))}
+            </View>
+          </View>
+        ))}
+      </ScrollView>
     </View>
   );
 }

--- a/app/(collector)/products.tsx
+++ b/app/(collector)/products.tsx
@@ -14,6 +14,7 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useProducts } from '@/hooks/useProducts';
 import { useCart } from '@/lib/cart';
+import { useNotifications } from '@/hooks/useNotifications';
 import { formatCurrency, formatShortDate } from '@/lib/formatters';
 import type { Product } from '@/types';
 
@@ -33,6 +34,7 @@ export default function ProductsScreen() {
     refresh,
   } = useProducts();
   const { addItem, updateQuantity, items, getItemCount, storeOrders, activeStoreId, setActiveStore } = useCart();
+  const { unreadCount } = useNotifications();
   const { storeId } = useLocalSearchParams<{ storeId?: string }>();
   const cartCount = getItemCount();
   const { width } = useWindowDimensions();
@@ -110,8 +112,18 @@ export default function ProductsScreen() {
           </View>
           <View className="flex-row items-center gap-3">
             {/* Notifications button */}
-            <TouchableOpacity onPress={() => router.push('/(collector)/notifications')}>
+            <TouchableOpacity
+              className="relative"
+              onPress={() => router.push('/(collector)/notifications')}
+            >
               <Ionicons name="notifications-outline" size={22} color="#374151" />
+              {unreadCount > 0 && (
+                <View className="absolute -top-2 -right-2 bg-red-500 rounded-full min-w-[16px] h-[16px] items-center justify-center">
+                  <Text className="text-white text-[9px] font-bold">
+                    {unreadCount > 99 ? '99+' : unreadCount}
+                  </Text>
+                </View>
+              )}
             </TouchableOpacity>
             {/* Order History button */}
             <TouchableOpacity

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -1,0 +1,76 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '@/lib/supabase';
+import { getNotifications, markAsRead, markAllAsRead } from '@/services/notifications.service';
+import type { Notification } from '@/types';
+
+export function useNotifications() {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const unreadCount = notifications.filter((n) => !n.is_read).length;
+
+  const fetch = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await getNotifications();
+      setNotifications(data);
+    } catch {
+      // silently fail — notifications are non-critical
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  // Realtime: prepend new notifications as they arrive
+  useEffect(() => {
+    let userId: string | null = null;
+
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session) return;
+      userId = session.user.id;
+
+      const channel = supabase
+        .channel('notifications-realtime')
+        .on(
+          'postgres_changes',
+          {
+            event: 'INSERT',
+            schema: 'public',
+            table: 'notifications',
+            filter: `user_id=eq.${userId}`,
+          },
+          (payload) => {
+            setNotifications((prev) => [payload.new as Notification, ...prev]);
+          }
+        )
+        .subscribe();
+
+      return () => { supabase.removeChannel(channel); };
+    });
+  }, []);
+
+  const handleMarkAsRead = useCallback(async (id: string) => {
+    setNotifications((prev) =>
+      prev.map((n) => (n.id === id ? { ...n, is_read: true } : n))
+    );
+    await markAsRead(id);
+  }, []);
+
+  const handleMarkAllAsRead = useCallback(async () => {
+    setNotifications((prev) => prev.map((n) => ({ ...n, is_read: true })));
+    await markAllAsRead();
+  }, []);
+
+  return {
+    notifications,
+    loading,
+    unreadCount,
+    markAsRead: handleMarkAsRead,
+    markAllAsRead: handleMarkAllAsRead,
+    refetch: fetch,
+  };
+}

--- a/services/notifications.service.ts
+++ b/services/notifications.service.ts
@@ -1,0 +1,37 @@
+import { supabase } from '@/lib/supabase';
+import type { Notification } from '@/types';
+
+export async function getNotifications(): Promise<Notification[]> {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) return [];
+
+  const { data, error } = await supabase
+    .from('notifications')
+    .select('*')
+    .eq('user_id', session.user.id)
+    .order('created_at', { ascending: false })
+    .limit(50);
+
+  if (error) throw new Error(error.message);
+  return data as Notification[];
+}
+
+export async function markAsRead(id: string): Promise<void> {
+  const { error } = await supabase
+    .from('notifications')
+    .update({ is_read: true })
+    .eq('id', id);
+  if (error) throw new Error(error.message);
+}
+
+export async function markAllAsRead(): Promise<void> {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) return;
+
+  const { error } = await supabase
+    .from('notifications')
+    .update({ is_read: true })
+    .eq('user_id', session.user.id)
+    .eq('is_read', false);
+  if (error) throw new Error(error.message);
+}

--- a/supabase/migrations/20260315000001_notifications.sql
+++ b/supabase/migrations/20260315000001_notifications.sql
@@ -1,0 +1,140 @@
+-- ============================================================
+-- Notifications table + triggers
+-- Covers: order status changes, low stock, out of stock,
+--         price changes
+-- ============================================================
+
+-- 1. Table
+create table if not exists public.notifications (
+  id         uuid        primary key default gen_random_uuid(),
+  user_id    uuid        not null references auth.users(id) on delete cascade,
+  type       text        not null,   -- 'order_status_changed' | 'low_stock' | 'out_of_stock' | 'price_changed'
+  title      text        not null,
+  body       text        not null,
+  data       jsonb       not null default '{}',
+  is_read    boolean     not null default false,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_notifications_user
+  on public.notifications(user_id, created_at desc);
+
+-- 2. RLS
+alter table public.notifications enable row level security;
+
+create policy "Users can read own notifications"
+  on public.notifications for select
+  using (auth.uid() = user_id);
+
+create policy "Users can mark own notifications read"
+  on public.notifications for update
+  using (auth.uid() = user_id);
+
+create policy "System can insert notifications"
+  on public.notifications for insert
+  with check (true);
+
+-- ============================================================
+-- 3. Trigger: order status changes → notify collector
+-- ============================================================
+create or replace function public.notify_order_status_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_title text;
+  v_body  text;
+begin
+  if OLD.status is distinct from NEW.status then
+    v_title := 'Order ' || NEW.order_number;
+    v_body := case NEW.status
+      when 'confirmed'  then 'Your order has been confirmed by the admin.'
+      when 'processing' then 'Your order is now being processed.'
+      when 'completed'  then 'Your order has been completed successfully.'
+      when 'cancelled'  then 'Your order has been cancelled.'
+      else 'Your order status changed to ' || NEW.status || '.'
+    end;
+
+    insert into public.notifications (user_id, type, title, body, data)
+    values (
+      NEW.collector_id,
+      'order_status_changed',
+      v_title,
+      v_body,
+      jsonb_build_object(
+        'order_id',     NEW.id,
+        'order_number', NEW.order_number,
+        'status',       NEW.status,
+        'store_id',     NEW.store_id
+      )
+    );
+  end if;
+  return NEW;
+end;
+$$;
+
+create trigger trg_notify_order_status
+  after update on public.orders
+  for each row execute function public.notify_order_status_change();
+
+-- ============================================================
+-- 4. Trigger: product stock/price changes → notify all active collectors
+-- ============================================================
+create or replace function public.notify_product_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_type  text;
+  v_title text;
+  v_body  text;
+begin
+  -- Out of stock (stock hits 0)
+  if NEW.stock_quantity = 0 and OLD.stock_quantity > 0 then
+    v_type  := 'out_of_stock';
+    v_title := NEW.name || ' is out of stock';
+    v_body  := 'Stock has reached 0 and can no longer be ordered.';
+
+  -- Low stock transition (drops into ≤10 zone)
+  elsif NEW.stock_quantity <= 10
+    and OLD.stock_quantity > 10
+    and NEW.stock_quantity > 0 then
+    v_type  := 'low_stock';
+    v_title := NEW.name || ' is running low';
+    v_body  := 'Only ' || NEW.stock_quantity || ' unit(s) remaining.';
+
+  -- Price change
+  elsif NEW.price is distinct from OLD.price then
+    v_type  := 'price_changed';
+    v_title := NEW.name || ' — price updated';
+    v_body  := 'Price changed from ₱' || OLD.price || ' to ₱' || NEW.price || '.';
+
+  else
+    return NEW;
+  end if;
+
+  insert into public.notifications (user_id, type, title, body, data)
+  select
+    p.id,
+    v_type,
+    v_title,
+    v_body,
+    jsonb_build_object(
+      'product_id',   NEW.id,
+      'product_name', NEW.name
+    )
+  from public.profiles p
+  where p.role      = 'collector'
+    and p.is_active = true;
+
+  return NEW;
+end;
+$$;
+
+create trigger trg_notify_product_change
+  after update on public.products
+  for each row execute function public.notify_product_change();

--- a/supabase/migrations/20260315000002_notify_new_product.sql
+++ b/supabase/migrations/20260315000002_notify_new_product.sql
@@ -1,0 +1,30 @@
+-- Notify all active collectors when a new product is added
+
+create or replace function public.notify_new_product()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.notifications (user_id, type, title, body, data)
+  select
+    p.id,
+    'new_product',
+    'New product: ' || NEW.name,
+    'A new product is now available to order.',
+    jsonb_build_object(
+      'product_id',   NEW.id,
+      'product_name', NEW.name
+    )
+  from public.profiles p
+  where p.role      = 'collector'
+    and p.is_active = true;
+
+  return NEW;
+end;
+$$;
+
+create trigger trg_notify_new_product
+  after insert on public.products
+  for each row execute function public.notify_new_product();

--- a/types/database.ts
+++ b/types/database.ts
@@ -74,3 +74,21 @@ export interface InventoryLog {
   performed_by: string;
   created_at: string;
 }
+
+export type NotificationType =
+  | 'order_status_changed'
+  | 'low_stock'
+  | 'out_of_stock'
+  | 'price_changed'
+  | 'new_product';
+
+export interface Notification {
+  id: string;
+  user_id: string;
+  type: NotificationType;
+  title: string;
+  body: string;
+  data: Record<string, any>;
+  is_read: boolean;
+  created_at: string;
+}


### PR DESCRIPTION
- Add notifications table with RLS and Supabase Realtime subscription
- Trigger on orders: notify collector when admin changes order status (confirmed, processing, completed, cancelled)
- Trigger on products UPDATE: notify all active collectors on low stock (≤10 units), out of stock (hits 0), and price changes
- Trigger on products INSERT: notify all active collectors when a new product is added
- Add NotificationType union and Notification interface to types
- Add notifications service (fetch, markAsRead, markAllAsRead)
- Add useNotifications hook with live Realtime inserts, no polling
- Build notifications screen grouped by day with per-type icons: blue receipt (order), orange warning (low stock), red circle (out of stock), purple tag (price), green sparkles (new product)
- Unread badge on bell icon in products header; mark-all-read bar